### PR TITLE
Email verification flow (sign up + change email) for Tutor and Student

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,7 +9,7 @@ import authRoutes from "./modules/user-management/auth.routes.js";
 import agencyRoutes from "./modules/user-management/agency.route.js";
 import agencyAdminRoutes from "./modules/user-management/agencyAdmin.routes.js";
 import { errorHandler } from "./middleware/errorHandler.js";
-
+import "./models/index.js"; 
 
 // Load environment variables
 dotenv.config();
@@ -63,11 +63,6 @@ const startServer = async () => {
     // Test database connection
     await sequelize.authenticate();
     console.log("Database connection has been established successfully.");
-
-    // Sync database models (create tables if they don't exist)
-    /*await sequelize.sync();
-    console.log("Database synchronized successfully.");
-    */
 
     // Start the server
     app.listen(PORT, "0.0.0.0", () => {

--- a/backend/src/models/emailVerification.model.js
+++ b/backend/src/models/emailVerification.model.js
@@ -1,0 +1,36 @@
+import { DataTypes } from "sequelize";
+import sequelize from "../config/database.js";
+
+const EmailVerificationToken = sequelize.define("EmailVerificationToken", {
+  id: {
+    type: DataTypes.UUID,
+    primaryKey: true,
+    defaultValue: DataTypes.UUIDV4,
+  },
+  userId: {
+    type: DataTypes.UUID,
+    allowNull: false,
+  },
+  tokenHash: {
+    type: DataTypes.STRING(255),
+    allowNull: false,
+  },
+  emailForVerification: {
+    type: DataTypes.STRING(100),
+    allowNull: false,
+  },
+  expiresAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+  usedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+}, {
+  tableName: "email_verification_tokens",
+  underscored: true,
+  indexes: [{ fields: ["user_id"] }, { fields: ["expires_at"] }],
+});
+
+export default EmailVerificationToken;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -12,6 +12,8 @@ import Location from './location.model.js';
 // Util imports
 import experienceLevelEnum from "../util/enum/experienceLevelEnum.js";
 
+import EmailVerificationToken from "./emailVerification.model.js";
+
 // Tutor-Subject Many-to-Many relationship
 const TutorSubject = sequelize.define(
   "TutorSubject",
@@ -93,4 +95,4 @@ User.belongsTo(Agency, { foreignKey: 'agencyId', as: 'agency' });
 Agency.hasMany(Location, { foreignKey: 'agencyId', as: 'locations' });
 Location.belongsTo(Agency, { foreignKey: 'agencyId', as: 'agency' });
 
-export { User, Subject, TutorSubject, Agency, PasswordResetToken, RefreshToken, Location, Sequelize, sequelize };
+export { User, Subject, TutorSubject, Agency, PasswordResetToken, RefreshToken, Location, Sequelize, sequelize, EmailVerificationToken};

--- a/backend/src/modules/user-management/auth.service.js
+++ b/backend/src/modules/user-management/auth.service.js
@@ -41,8 +41,16 @@ export default class AuthService {
       throw new Error("Admin accounts cannot log in here");
     }
 
-    if (!user.isActive || user.isSuspended) {
+    if (user.isSuspended) {
       throw new Error("Account is deactivated. Please contact support.");
+    }
+
+    if (!user.isActive) {
+      return res.status(403).json({
+        success: false,
+        code: "ACCOUNT_INACTIVE",
+        message: "Please verify your email to continue.",
+      });
     }
 
     const passwordMatch = await bcrypt.compare(password, user.password);

--- a/backend/src/modules/user-management/emailVerification.service.js
+++ b/backend/src/modules/user-management/emailVerification.service.js
@@ -1,0 +1,113 @@
+import crypto from "crypto";
+import { Op } from "sequelize";
+import { User, EmailVerificationToken } from "../../models/index.js";
+import { sendEmail } from "../../util/mailer.js";
+import { verifyEmailTemplate } from "../../util/emailTemplates.js";
+
+const TOKEN_TTL_MINUTES = 60;
+
+function hashToken(t) {
+  return crypto.createHash("sha256").update(String(t)).digest("hex");
+}
+function makeRandomToken() {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+export async function createAndEmailVerificationLink({ user, email }) {
+  // Invalidate existing unused tokens for this user + target email
+  await EmailVerificationToken.update(
+    { usedAt: new Date() },
+    { where: { userId: user.id, emailForVerification: email, usedAt: null } }
+  );
+
+  const token = makeRandomToken();
+  const tokenHash = hashToken(token);
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_MINUTES * 60 * 1000);
+
+  await EmailVerificationToken.create({
+    userId: user.id,
+    tokenHash,
+    emailForVerification: email,
+    expiresAt,
+  });
+
+  const baseUrl = process.env.APP_BASE_URL || "http://localhost:3000";
+  const verifyLink = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}`;
+
+  const { subject, text, html } = verifyEmailTemplate({
+    name: user.firstName || "there",
+    verifyLink,
+    ttlMinutes: TOKEN_TTL_MINUTES,
+  });
+
+  await sendEmail({ to: email, subject, text, html });
+}
+
+export async function verifyEmailToken(rawToken) {
+  const tokenHash = hashToken(rawToken);
+
+  const record = await EmailVerificationToken.findOne({
+    where: {
+      tokenHash,
+      usedAt: null,
+      expiresAt: { [Op.gt]: new Date() },
+    },
+  });
+
+  if (!record) return { ok: false, reason: "invalid_or_expired" };
+
+  const user = await User.findByPk(record.userId);
+  if (!user) return { ok: false, reason: "user_not_found" };
+
+  // If this token is for a pending new email, swap it in
+  if (user.email !== record.emailForVerification) {
+    user.email = record.emailForVerification;
+  }
+
+  user.isActive = true;
+  await user.save();
+
+  record.usedAt = new Date();
+  await record.save();
+
+  return { ok: true, userId: user.id, email: user.email };
+}
+
+/**
+ * Return the latest pending (unexpired, unused) email_for_verification for a user, if any.
+ */
+export async function getPendingEmailForUser(userId) {
+  const latest = await EmailVerificationToken.findOne({
+    where: {
+      userId,
+      usedAt: null,
+      expiresAt: { [Op.gt]: new Date() },
+    },
+    order: [["createdAt", "DESC"]],
+  });
+  return latest?.emailForVerification || null;
+}
+
+/**
+ * Resend verification to the authenticated user's pending email if exists,
+ * otherwise fall back to their current email.
+ */
+export async function resendVerificationForUser(userId) {
+  const user = await User.findByPk(userId);
+  if (!user) return { ok: true };          // don't leak existence
+  if (user.isActive) return { ok: true };  // already verified
+
+  const target = (await getPendingEmailForUser(user.id)) || user.email;
+  await createAndEmailVerificationLink({ user, email: target });
+  return { ok: true };
+}
+
+/**
+ * Backward-compat wrapper for any existing callers that pass an email.
+ * Prefer calling resendVerificationForUser(userId).
+ */
+export async function resendVerification(email) {
+  const user = await User.findOne({ where: { email } });
+  if (!user) return { ok: true };
+  return resendVerificationForUser(user.id);
+}

--- a/backend/src/util/emailTemplates.js
+++ b/backend/src/util/emailTemplates.js
@@ -49,3 +49,31 @@ If you didn’t request this, you can ignore this email.
   </div>`;
   return { subject, text, html };
 }
+
+export function verifyEmailTemplate({ name = "there", verifyLink, ttlMinutes = 60 }) {
+  const subject = "Verify your Tutiful email";
+  const text =
+`Hi ${name},
+
+Please verify your email by clicking the link below:
+${verifyLink}
+
+This link expires in ${ttlMinutes} minutes.
+
+— Tutiful`;
+
+  const html = `
+  <div style="font-family:Arial,sans-serif;line-height:1.6">
+    <p>Hi ${name},</p>
+    <p>Please verify your email by clicking the button below:</p>
+    <p>
+      <a href="${verifyLink}" style="display:inline-block;padding:10px 16px;
+         background:#111;color:#fff;text-decoration:none;border-radius:6px">
+        Verify Email
+      </a>
+    </p>
+    <p>This link expires in <b>${ttlMinutes} minutes</b>.</p>
+    <p>— Tutiful</p>
+  </div>`;
+  return { subject, text, html };
+}

--- a/mobile/app/login.jsx
+++ b/mobile/app/login.jsx
@@ -76,6 +76,13 @@ export default function LoginScreen() {
       }
     } catch (error) {
       console.error("Login error:", error);
+
+      if (error?.response?.code === "ACCOUNT_INACTIVE" || error?.code === "ACCOUNT_INACTIVE") {
+        router.replace({ pathname: "/verify_email", params: { email } });
+        return;
+      }
+
+
       Alert.alert(
         "Login Failed",
         error.message || "Invalid credentials. Please try again."

--- a/mobile/app/register.jsx
+++ b/mobile/app/register.jsx
@@ -70,7 +70,8 @@ export default function RegisterScreen() {
             }
 
             console.log("Registration successful:", data);
-            router.replace("/login");
+            // router.replace("/login");
+            router.replace({ pathname: "/verify_email", params: { email } });
         } catch (error) {
             console.error("Registration error:", error);
 

--- a/mobile/app/tabs/editStudent.js
+++ b/mobile/app/tabs/editStudent.js
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet, Alert } from "react-native";
+import { View, Text, StyleSheet, Alert, ActivityIndicator, Pressable } from "react-native";
 import React, { useState, useEffect } from "react";
 import { Ionicons } from "@expo/vector-icons";
 import Form from "../../components/form";
@@ -6,7 +6,7 @@ import { Link, useLocalSearchParams, router } from "expo-router";
 import authService from "../../services/authService";
 import apiClient from "../../services/apiClient";
 import { validateName, validateEmail, validatePhone, validateDateOfBirth } from "../utils/validation";
-import { jwtDecode } from "jwt-decode"
+import { jwtDecode } from "jwt-decode";
 import supabase from "../../services/supabaseClient";
 
 export default function editStudent() {
@@ -18,15 +18,51 @@ export default function editStudent() {
   const [currentUserId, setCurrentUserId] = useState(null);
   const [errors, setErrors] = useState({});
 
+  // Email verification UI state
+  const [isActive, setIsActive] = useState(true);
+  const [polling, setPolling] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(90);
+  const pollRef = React.useRef(null);
+
+  // NEW: resend cooldown state (60s)
+  const [resendSecondsLeft, setResendSecondsLeft] = useState(0);
+  const cooldownRef = React.useRef(null);
+
   useEffect(() => {
     fetchStudentData();
+    // cleanup any timers if you navigate away
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      if (cooldownRef.current) {
+        clearInterval(cooldownRef.current);
+        cooldownRef.current = null;
+      }
+    };
   }, []);
+
+  // NEW: tick down the resend cooldown
+  useEffect(() => {
+    if (resendSecondsLeft <= 0) return;
+    if (cooldownRef.current) clearInterval(cooldownRef.current);
+    cooldownRef.current = setInterval(() => {
+      setResendSecondsLeft((s) => (s > 1 ? s - 1 : 0));
+    }, 1000);
+    return () => {
+      if (cooldownRef.current) {
+        clearInterval(cooldownRef.current);
+        cooldownRef.current = null;
+      }
+    };
+  }, [resendSecondsLeft]);
 
   const fetchStudentData = async () => {
     try {
       setLoading(true);
 
-      //Get the authenticated user's ID
+      // Get the authenticated user's ID
       let studentId = id;
       if (!studentId && authService.isAuthenticated()) {
         const token = await authService.getCurrentToken();
@@ -46,33 +82,36 @@ export default function editStudent() {
       const studentData = await apiClient.get(`/students/${studentId}`);
 
       console.log("Fetched student data:", studentData);
+
+      // Prefer pendingEmail for display so the new email shows immediately
+      const displayEmail = studentData.pendingEmail || studentData.email || "";
+
       // Update form data with fetched data
       setFormData({
         firstName: studentData.firstName || "",
         lastName: studentData.lastName || "",
         dateOfBirth: studentData.dateOfBirth || "",
-        email: studentData.email || "",
+        email: displayEmail,
         phone: studentData.phone || "",
         gender: studentData.gender || "",
         gradeLevel: studentData.gradeLevel || "",
         image: studentData.image || "",
       });
+      setIsActive(!!studentData.isActive);
 
       setInitialData({
         firstName: studentData.firstName || "",
         lastName: studentData.lastName || "",
         dateOfBirth: studentData.dateOfBirth || "",
-        email: studentData.email || "",
+        email: displayEmail, // baseline matches what's displayed
         phone: studentData.phone || "",
         gender: studentData.gender || "",
         gradeLevel: studentData.gradeLevel || "",
         image: studentData.image || "",
       });
-
     } catch (error) {
       console.error("Error fetching student data:", error);
       Alert.alert("Error", "An error occurred while fetching data");
-      console.error("Error fetching student data:", error);
     } finally {
       setLoading(false);
     }
@@ -94,28 +133,25 @@ export default function editStudent() {
 
     // real time validation
     let error = "";
-    if (field === 'firstName' || field === 'lastName') {
+    if (field === "firstName" || field === "lastName") {
       error = validateName(value);
-    }
-    else if (field === 'email') {
+    } else if (field === "email") {
       error = validateEmail(value);
-    }
-    else if (field === 'phone') {
+    } else if (field === "phone") {
       error = validatePhone(value);
-    }
-    else if (field === 'dateOfBirth') {
+    } else if (field === "dateOfBirth") {
       error = validateDateOfBirth(value);
     }
     setErrors((prev) => ({
       ...prev,
-      [field]: error
+      [field]: error,
     }));
   };
 
   const handleSave = async () => {
-    setErrors({}); //clear prev errors
+    setErrors({}); // clear prev errors
 
-    //validate fields
+    // validate fields
     const emailError = validateEmail(formData.email);
     const phoneError = validatePhone(formData.phone);
     const firstNameError = validateName(formData.firstName);
@@ -123,7 +159,6 @@ export default function editStudent() {
     const dateOfBirthError = validateDateOfBirth(formData.dateOfBirth);
 
     if (emailError || phoneError || firstNameError || lastNameError || dateOfBirthError) {
-
       setErrors({
         email: emailError,
         phone: phoneError,
@@ -137,37 +172,37 @@ export default function editStudent() {
     // Upload image to Supabase Storage if it's a local file
     let imageUrl = formData.image;
     let imageUploaded = false;
-    if (imageUrl && imageUrl.startsWith('file://')) {
+    if (imageUrl && imageUrl.startsWith("file://")) {
       try {
-        const imageExt = imageUrl.split('.').pop();
+        const imageExt = imageUrl.split(".").pop();
 
-        let contentType = 'image/png'; // default
-        if (imageExt === 'jpg' || imageExt === 'jpeg') {
-          contentType = 'image/jpeg';
-        } else if (imageExt === 'png') {
-          contentType = 'image/png';
+        let contentType = "image/png"; // default
+        if (imageExt === "jpg" || imageExt === "jpeg") {
+          contentType = "image/jpeg";
+        } else if (imageExt === "png") {
+          contentType = "image/png";
         } // add more types as needed
 
         const fileName = `student_${currentUserId || id}`;
         const response = await fetch(imageUrl);
         const arrayBuffer = await response.arrayBuffer();
-        const { data, error } = await supabase.storage.from('avatars').upload(fileName, arrayBuffer, {
-          cacheControl: '3600',
+        const { data, error } = await supabase.storage.from("avatars").upload(fileName, arrayBuffer, {
+          cacheControl: "3600",
           upsert: true,
-          contentType: contentType // sets the correct MIME type,
+          contentType: contentType, // sets the correct MIME type
         });
         console.log("Supabase upload response:", data, error);
         if (error) {
-          throw new Error('Image upload failed: ' + error.message);
+          throw new Error("Image upload failed: " + error.message);
         }
         // Get public URL
-        const { data: urlData } = supabase.storage.from('avatars').getPublicUrl(fileName);
+        const { data: urlData } = supabase.storage.from("avatars").getPublicUrl(fileName);
         imageUrl = urlData.publicUrl;
         imageUploaded = true;
         console.log("Image public URL:", imageUrl);
         // Do NOT rely on setFormData here, just use imageUrl for PATCH
       } catch (err) {
-        Alert.alert('Error', 'Image upload failed: ' + err.message);
+        Alert.alert("Error", "Image upload failed: " + err.message);
         return;
       }
     }
@@ -176,9 +211,9 @@ export default function editStudent() {
       const requestBody = {};
       Object.keys(formData).forEach((key) => {
         // If a new image was uploaded, always set image field
-        if (key === 'image' && imageUploaded) {
+        if (key === "image" && imageUploaded) {
           requestBody[key] = imageUrl;
-        } else if (formData[key] !== initialData[key] && key !== 'image') {
+        } else if (formData[key] !== initialData[key] && key !== "image") {
           requestBody[key] = formData[key];
         }
       });
@@ -194,16 +229,15 @@ export default function editStudent() {
 
       await apiClient.patch(`/students/${studentId}`, requestBody);
 
+      // Immediately refresh so we pick up isActive=false and pendingEmail if email changed
+      await fetchStudentData();
+
       console.log("✅ Personal details updated successfully");
-      // Use Alert for React Native compatibility
       Alert.alert(
         "Success",
         "Personal details updated successfully! Go back to profile?",
         [
-          {
-            text: "Stay Here",
-            style: "cancel",
-          },
+          { text: "Stay Here", style: "cancel" },
           {
             text: "Go Back",
             onPress: () => {
@@ -214,24 +248,118 @@ export default function editStudent() {
       );
     } catch (error) {
       console.error("Error updating profile:", error);
-      // Use Alert for React Native compatibility
-      Alert.alert(
-        "Error",
-        "An error occurred while updating profile. Please try again."
+      Alert.alert("Error", "An error occurred while updating profile. Please try again.");
+    }
+  };
+
+  // ----- Email verification helpers -----
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    setPolling(false);
+    setSecondsLeft(90);
+  };
+
+  const startPollingForVerification = (studentId) => {
+    stopPolling();
+    setPolling(true);
+    setSecondsLeft(90);
+    pollRef.current = setInterval(async () => {
+      setSecondsLeft((s) => (s > 0 ? s - 1 : 0));
+      try {
+        const fresh = await apiClient.get(`/students/${studentId}`);
+        if (fresh?.isActive) {
+          stopPolling();
+          setIsActive(true);
+          Alert.alert("Verified!", "Your email is now verified.");
+          // pull the final official email (DB value)
+          await fetchStudentData();
+        }
+      } catch {
+        // ignore transient errors during polling
+      }
+    }, 3000);
+
+    // hard stop after 90s
+    setTimeout(() => {
+      if (pollRef.current) {
+        stopPolling();
+      }
+    }, 90000);
+  };
+
+  const onPressVerify = async () => {
+    try {
+      await authService.resendVerification(); // backend uses auth to target correct address
+      setResendSecondsLeft(60);               // <<< start 60s cooldown
+      Alert.alert("Verification sent", "Check your inbox for the verification link.");
+      const studentId = currentUserId || id;
+      startPollingForVerification(studentId);
+    } catch (e) {
+      const msg = e?.message || "We couldn't send the verification email. Please try again.";
+      Alert.alert("Failed to send", msg);
+    }
+  };
+
+  // render content right under the Email field
+  const renderBelowEmail = () => {
+    if (!formData?.email) return null;
+
+    if (isActive) {
+      return (
+        <View style={[styles.verifyRow, { marginTop: 6 }]}>
+          <Ionicons name="checkmark-circle" size={18} color="green" />
+          <Text style={styles.verifiedText}>Email verified</Text>
+        </View>
       );
     }
+
+    return (
+      <View style={{ marginTop: 6 }}>
+        <View style={styles.verifyRow}>
+          <Ionicons name="warning-outline" size={18} color="#E67E22" />
+          <Text style={styles.unverifiedText}>Email not verified</Text>
+        </View>
+
+        <View style={styles.actionsRow}>
+          <Pressable
+            onPress={onPressVerify}
+            disabled={polling || resendSecondsLeft > 0}                    // <<< disable during cooldown
+            style={({ pressed }) => [
+              styles.verifyButton,
+              { opacity: (polling || resendSecondsLeft > 0) ? 0.6 : pressed ? 0.8 : 1 },
+            ]}
+          >
+            {polling ? (
+              <ActivityIndicator />
+            ) : (
+              <Text style={styles.verifyButtonText}>
+                {resendSecondsLeft > 0 ? `Resend in ${resendSecondsLeft}s` : "Resend Verification"}
+              </Text>
+            )}
+          </Pressable>
+
+          {polling ? (
+            <Text style={styles.waitingText}>Waiting… {secondsLeft}s</Text>
+          ) : (
+            <Pressable onPress={fetchStudentData}>
+              <Text style={styles.refreshText}>Refresh status</Text>
+            </Pressable>
+          )}
+
+          {/* Removed the Stop button for minimal UX as requested */}
+        </View>
+      </View>
+    );
   };
 
   return (
     <View style={styles.container}>
       <View style={styles.header}>
         <Link href="/tabs/myProfile" style={styles.backLink}>
-          <Ionicons
-            name="arrow-back"
-            size={24}
-            color="#6155F5"
-            style={{ marginBottom: 20 }}
-          />
+          <Ionicons name="arrow-back" size={24} color="#6155F5" style={{ marginBottom: 20 }} />
         </Link>
         <Text style={styles.title}>Edit Profile</Text>
       </View>
@@ -245,6 +373,8 @@ export default function editStudent() {
         showGender={true}
         saveButtonText="Save"
         errors={errors}
+        /** status/verify row lives directly under the Email field */
+        renderBelowEmail={renderBelowEmail}
       />
     </View>
   );
@@ -275,8 +405,51 @@ const styles = StyleSheet.create({
     color: "#6155F5",
   },
   center: {
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     flex: 1,
+  },
+  // --- verify UI ---
+  verifyRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  verifiedText: {
+    color: "green",
+    fontWeight: "600",
+    marginLeft: 6,
+  },
+  unverifiedText: {
+    color: "#E67E22",
+    fontWeight: "600",
+    marginLeft: 6,
+  },
+  actionsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginTop: 8,
+  },
+  verifyButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+  },
+  verifyButtonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  waitingText: {
+    color: "#333",
+  },
+  refreshText: {
+    color: "#2563EB",
+    textDecorationLine: "underline",
+  },
+  stopText: {
+    color: "#666",
+    textDecorationLine: "underline",
   },
 });

--- a/mobile/app/verify_email.jsx
+++ b/mobile/app/verify_email.jsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import authService from "../services/authService.js";
+
+const RESEND_SECONDS = 60;
+
+export default function VerifyEmailScreen() {
+  const router = useRouter();
+  const { email = "" } = useLocalSearchParams();
+  const [secondsLeft, setSecondsLeft] = useState(RESEND_SECONDS);
+  const timerRef = useRef(null);
+
+  // Start cooldown on mount
+  useEffect(() => {
+    startCooldown();
+    return () => stopCooldown();
+  }, []);
+
+  const startCooldown = () => {
+    stopCooldown();
+    setSecondsLeft(RESEND_SECONDS);
+    timerRef.current = setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          clearInterval(timerRef.current);
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+  };
+
+  const stopCooldown = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const canResend = secondsLeft === 0;
+
+  const resend = async () => {
+    if (!canResend) return;
+    try {
+      await authService.resendVerification(String(email));
+      alert("If your account is unverified, we've sent a new email.");
+      startCooldown(); // restart cooldown after resend
+    } catch (e) {
+      alert("Failed to resend. Try again later.");
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Check your email</Text>
+      <Text style={styles.body}>
+        We’ve sent a verification link to{" "}
+        <Text style={{ fontWeight: "600" }}>{email}</Text>. Click the link to
+        verify, then return to login.
+      </Text>
+
+      <TouchableOpacity
+        style={styles.primary}
+        onPress={() => router.replace("/login")}
+      >
+        <Text style={styles.primaryText}>Back to Login</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[
+          styles.secondary,
+          !canResend && { opacity: 0.5, borderColor: "#eee" },
+        ]}
+        onPress={resend}
+        disabled={!canResend}
+      >
+        <Text style={styles.secondaryText}>
+          {canResend
+            ? "Resend verification email"
+            : `Resend available in ${secondsLeft}s`}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: "center", gap: 16 },
+  title: { fontSize: 24, fontWeight: "700" },
+  body: { fontSize: 16, lineHeight: 22 },
+  primary: {
+    backgroundColor: "black",
+    padding: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  primaryText: { color: "white", fontWeight: "600" },
+  secondary: {
+    padding: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#ddd",
+  },
+  secondaryText: { color: "black", fontWeight: "600" },
+});

--- a/mobile/components/form.js
+++ b/mobile/components/form.js
@@ -23,6 +23,8 @@ const Form = ({
   errors,
   showGradeLevel = true,
   showGender = true,
+  /** NEW: slot to render content right under the Email input */
+  renderBelowEmail,
 }) => {
 
   /* State for gender picker modal */
@@ -32,7 +34,6 @@ const Form = ({
     { label: "Male", value: "male" },
     { label: "Female", value: "female" },
   ]);
-
 
   /* State for grade level picker modal */
   const [gradeOpen, setGradeOpen] = useState(false);
@@ -61,7 +62,7 @@ const Form = ({
     setShowDatePicker(false);
     if (selectedDate) {
       setDateValue(selectedDate);
-      // Format date as DD-MM-YYYY string
+      // Format date as YYYY-MM-DD string
       const iso = selectedDate.toISOString().split('T')[0];
       onInputChange('dateOfBirth', iso);
     }
@@ -71,7 +72,6 @@ const Form = ({
   const [image, setImage] = useState(formData.image || null);
 
   /* Function to handle image selection */
-
   const pickImage = async () => {
     // Ask for permission first
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -162,7 +162,7 @@ const Form = ({
       </View>
 
       {/* Email */}
-      <View style={styles.inputContainer}>
+      <View className="email-field" style={styles.inputContainer}>
         <Ionicons name="mail-outline" size={20} style={styles.styleIcon} />
         <TextInput
           style={[styles.input, styles.inputWithIcon, errors.email && styles.inputError]}
@@ -170,10 +170,16 @@ const Form = ({
           value={formData.email}
           onChangeText={(text) => onInputChange("email", text)}
           keyboardType="email-address"
+          autoCapitalize="none"
         />
         {errors.email && (
           <Text style={styles.errorText}>{errors.email}</Text>
         )}
+
+        {/* NEW: render verification row directly under the Email field */}
+        {renderBelowEmail
+          ? (typeof renderBelowEmail === "function" ? renderBelowEmail() : renderBelowEmail)
+          : null}
       </View>
 
       {/* Phone Number */}
@@ -315,10 +321,10 @@ const styles = StyleSheet.create({
     height: 50,
     width: "100%",
     color: "#374151",
-    backgroundColor: "#fff", // Ensure background color matches
-    borderWidth: 0, // No border
-    borderRadius: 12, // Rounded corners
-    shadowColor: "#000", // Add shadow
+    backgroundColor: "#fff",
+    borderWidth: 0,
+    borderRadius: 12,
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.05,
     shadowRadius: 4,

--- a/mobile/services/apiClient.js
+++ b/mobile/services/apiClient.js
@@ -58,9 +58,13 @@ class ApiClient {
     return !!this.accessToken;
   }
 
-  // Core HTTP request method with automatic token refresh
+  // // Core HTTP request method with automatic token refresh
+  // async request(endpoint, options = {}, isRetry = false) {
+  //   const url = `${this.baseURL}${endpoint}`;
+
   async request(endpoint, options = {}, isRetry = false) {
-    const url = `${this.baseURL}${endpoint}`;
+  const url = `${this.baseURL}${endpoint}`;
+  const skipAuth = !!options._skipAuth; // 🔑 CHANGE: allow public calls
 
     // Build headers
     const headers = {
@@ -69,7 +73,12 @@ class ApiClient {
     };
 
     // Add Authorization header if access token is available
-    if (this.accessToken) {
+    // if (this.accessToken) {
+    //   headers.Authorization = `Bearer ${this.accessToken}`;
+    // }
+
+    // Add Authorization header only if we have token AND not skipping
+    if (!skipAuth && this.accessToken) {
       headers.Authorization = `Bearer ${this.accessToken}`;
     }
 
@@ -85,8 +94,11 @@ class ApiClient {
 
       const response = await fetch(url, config);
 
-      // Handle 401 Unauthorized - try to refresh token
-      if (response.status === 401 && !isRetry && endpoint !== "/auth/refresh") {
+      // // Handle 401 Unauthorized - try to refresh token
+      // if (response.status === 401 && !isRetry && endpoint !== "/auth/refresh") {
+      
+      // Handle 401 Unauthorized - try to refresh token (but not on skipAuth calls)
+      if (!skipAuth && response.status === 401 && !isRetry && endpoint !== "/auth/refresh") {
         console.log("Received 401, attempting token refresh...");
         try {
           await this.refreshToken();

--- a/mobile/services/authService.js
+++ b/mobile/services/authService.js
@@ -5,7 +5,6 @@ class AuthService {
   async login(email, password) {
     try {
       const response = await apiClient.login(email, password);
-
       return response; // Only return if success
     } catch (error) {
       console.error("Login failed:", error);
@@ -62,6 +61,27 @@ class AuthService {
       // If refresh fails, user needs to login again
       return false;
     }
+  }
+
+  // // ⬇️ UPDATED: don't send email in body; backend uses auth user + pending token
+  // async resendVerification() {
+  //   const res = await apiClient.request("/auth/resend-verification", {
+  //     method: "POST",
+  //     headers: { "Content-Type": "application/json" },
+  //     body: JSON.stringify({}), // explicit empty body is fine; or omit body entirely if your request helper allows
+  //   });
+  //   return res;
+  // }
+
+  // Resend verification email (public endpoint, no token required)
+  async resendVerification(email) {
+    const res = await apiClient.request("/auth/resend-verification", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }), // backend expects email
+      _skipAuth: true, // 🔑 CHANGE: prevent adding Bearer token
+    });
+    return res;
   }
 }
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -34,6 +34,11 @@ function AppRoutes() {
       <Route path="/forgot-password/verify" element={<VerifyCode />} />
       <Route path="/forgot-password/new" element={<NewPassword />} />
       <Route path="/forgot-password/success" element={<ResetSuccess />} />
+      {/* Agency aliases reusing the same screens with context */}
+      <Route path="/agency/forgot/email" element={<ForgotEmail context="agency" />} />
+      <Route path="/agency/forgot/verify" element={<VerifyCode context="agency" />} />
+      <Route path="/agency/forgot/new-password" element={<NewPassword context="agency" />} />
+      <Route path="/agency/forgot/success" element={<ResetSuccess context="agency" />} />
       {/* Admin */}
       <Route
         path="/admin/*"

--- a/web/src/pages/ForgotPassword/ForgotEmail.jsx
+++ b/web/src/pages/ForgotPassword/ForgotEmail.jsx
@@ -23,10 +23,16 @@ function isSuccessResponse(resLike) {
   return isHttpOk || hasSuccessFlag || hasSuccessWords;
 }
 
-export default function ForgotEmail() {
+export default function ForgotEmail({ context }) {
   const [email, setEmail] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const navigate = useNavigate();
+
+  // === NEW: context-aware paths (works even if no prop is passed) ===
+  const isAgency = context === "agency" || window.location.pathname.startsWith("/agency/");
+  const baseForgotPath = isAgency ? "/agency/forgot-password" : "/forgot-password";
+  const loginPath = isAgency ? "/agency" : "/login";
+  // =================================================================
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -54,8 +60,8 @@ export default function ForgotEmail() {
         // Persist for Verify page
         localStorage.setItem("resetEmail", trimmed);
 
-        // Carry the email in route state too
-        navigate("/forgot-password/verify", { state: { email: trimmed, justSent: true }, replace: true });
+        // === CHANGED: use context-aware path ===
+        navigate(`${baseForgotPath}/verify`, { state: { email: trimmed, justSent: true }, replace: true });
       } else {
         const data = res?.data ?? res ?? {};
         notifications.show({
@@ -72,7 +78,8 @@ export default function ForgotEmail() {
       if (/sent/i.test(msg)) {
         notifications.show({ color: "green", title: "Code sent", message: msg || "Check your inbox for the 6-digit code." });
         localStorage.setItem("resetEmail", trimmed);
-        navigate("/forgot-password/verify", { state: { email: trimmed, justSent: true }, replace: true });
+        // === CHANGED: use context-aware path ===
+        navigate(`${baseForgotPath}/verify`, { state: { email: trimmed, justSent: true }, replace: true });
       } else {
         notifications.show({ color: "red", title: "Server error", message: msg || "Please try again." });
       }
@@ -112,7 +119,8 @@ export default function ForgotEmail() {
 
               <Text size="sm" c="dimmed">
                 Remembered your password?{" "}
-                <Anchor onClick={() => navigate("/login")} component="button" type="button">
+                {/* CHANGED: back to login respects Agency context */}
+                <Anchor onClick={() => navigate(loginPath)} component="button" type="button">
                   Back to login
                 </Anchor>
               </Text>

--- a/web/src/pages/ForgotPassword/NewPassword.jsx
+++ b/web/src/pages/ForgotPassword/NewPassword.jsx
@@ -34,9 +34,14 @@ function passwordScore(issues) {
   return Math.round((good / total) * 100);
 }
 
-export default function NewPassword() {
+export default function NewPassword({ context }) {
   const navigate = useNavigate();
   const location = useLocation();
+
+  // === NEW: context-aware paths ===
+  const isAgency = context === "agency" || window.location.pathname.startsWith("/agency/");
+  const baseForgotPath = isAgency ? "/agency/forgot-password" : "/forgot-password";
+  // ================================
 
   const emailFromState = location?.state?.email;
   const tokenFromState = location?.state?.resetToken;
@@ -59,12 +64,13 @@ export default function NewPassword() {
         title: "Session expired",
         message: "Please verify your email again.",
       });
-      navigate("/forgot-password", { replace: true });
+      // CHANGED: go back to the context-aware start page
+      navigate(baseForgotPath, { replace: true });
       return;
     }
     sessionStorage.setItem("fp_email", email);
     sessionStorage.setItem("fp_reset_token", resetToken);
-  }, [email, resetToken, navigate]);
+  }, [email, resetToken, navigate, baseForgotPath]);
 
   const issues = useMemo(() => passwordIssues(email, pwd), [email, pwd]);
   const score = useMemo(() => passwordScore(issues), [issues]);
@@ -77,7 +83,8 @@ export default function NewPassword() {
         title: "Missing token",
         message: "Please restart the reset process.",
       });
-      navigate("/forgot-password", { replace: true });
+      // CHANGED: context-aware
+      navigate(baseForgotPath, { replace: true });
       return;
     }
     if (pwd !== pwd2) {
@@ -121,7 +128,8 @@ export default function NewPassword() {
         message: "You can now log in with your new password.",
       });
 
-      navigate("/forgot-password/success", { replace: true });
+      // CHANGED: context-aware success route
+      navigate(`${baseForgotPath}/success`, { replace: true });
     } catch (err) {
       notifications.show({
         color: "red",

--- a/web/src/pages/ForgotPassword/ResetSuccess.jsx
+++ b/web/src/pages/ForgotPassword/ResetSuccess.jsx
@@ -2,10 +2,14 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { Title, Text, Button, Stack, Image, Box } from "@mantine/core";
 import logo from "../../assets/tooty.png";
 
-export default function ResetSuccess() {
+export default function ResetSuccess({ context }) {
   const navigate = useNavigate();
   const location = useLocation();
   const fromReset = location?.state?.fromReset;
+
+  // NEW: context-aware login destination
+  const isAgency = context === "agency" || window.location.pathname.startsWith("/agency/");
+  const loginPath = isAgency ? "/agency" : "/login";
 
   const title = fromReset ? "Password reset successful" : "Action completed";
   const description = fromReset
@@ -32,7 +36,7 @@ export default function ResetSuccess() {
             radius="md"
             fullWidth
             styles={{ root: { height: 44 } }}
-            onClick={() => navigate("/login")}
+            onClick={() => navigate(loginPath)} // CHANGED
           >
             Go to Login
           </Button>


### PR DESCRIPTION
- Add verification token model + hashed storage, single-use, short expiry
- New endpoints: POST /auth/register, GET /auth/verify, POST /auth/resend-verification
- Enforce isActive=false until verified; flip to true on successful verify
- Email-change flow: set isActive=false, send verify link to new email
- Throttle resend (60s), return remaining wait if early
- Web/Mobile: Verify screen with 60s cooldown, status pill, and auto-refresh
- Login guard returns ACCOUNT_NOT_VERIFIED for inactive accounts
- Minimal Form.js changes: renderBelowEmail slot and status refresh